### PR TITLE
fix: preserve session data beyond browser-refresh

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -19,7 +19,10 @@ function App() {
 
   const [users, setUsers] = useState([]);
 
-  const [estimation, setEstimation] = useState(null);
+  const [estimation, setEstimation] = useState(
+    sessionStorage.getItem("estimation") || null,
+  );
+
   const [userNameSubmitted, setUserNameSubmitted] = useState(
     sessionStorage.getItem("userNameSubmitted") || false,
   );
@@ -42,6 +45,7 @@ function App() {
 
   // Whenever state changes, write session data to sessionStorage
   useEffect(() => {
+    sessionStorage.setItem("estimation", estimation);
     sessionStorage.setItem("userName", userName);
     sessionStorage.setItem("userNameSubmitted", userNameSubmitted);
   });

--- a/src/App.js
+++ b/src/App.js
@@ -12,10 +12,17 @@ import {
 import "./estimationButtons.css";
 
 function App() {
-  const [userName, setUserName] = useState("");
+
+  const [userName, setUserName] = useState(
+    sessionStorage.getItem("userName") || ""
+  );
+
   const [users, setUsers] = useState([]);
+
   const [estimation, setEstimation] = useState(null);
-  const [userNameSubmitted, setUserNameSubmitted] = useState(false);
+  const [userNameSubmitted, setUserNameSubmitted] = useState(
+    sessionStorage.getItem("userNameSubmitted") || false,
+  );
 
   // create function to update users state by sending a GET request to the server
   const updateUsers = () => {
@@ -32,6 +39,12 @@ function App() {
       })
       .catch((error) => console.error(error));
   };
+
+  // Whenever state changes, write session data to sessionStorage
+  useEffect(() => {
+    sessionStorage.setItem("userName", userName);
+    sessionStorage.setItem("userNameSubmitted", userNameSubmitted);
+  });
 
   useEffect(() => {
     const hash = window.location.hash.slice(1); // remove the "#" character


### PR DESCRIPTION
## Change
`userName` and `userNameSubmitted` are now written to and read from the `sessionStorage`. This prevents that session data from being wiped out whenever the browser gets refreshed.

* I didn't add the `users` list to it because that is stored on the server right now.