### PR TITLE
Refreshing disables cards

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "dbaeumer.vscode-eslint"
+    ]
+}

--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import axios from "axios";
 import io from "socket.io-client";
 import ParticipantList from "./ParticipantList";
@@ -29,7 +29,7 @@ function App() {
   const [userNameSubmitted, setUserNameSubmitted] = useStateWithSessionStorage("userNameSubmitted", false);
 
   // create function to update users state by sending a GET request to the server
-  const updateUsers = () => {
+  const updateUsers = useCallback(() => {
     axios
       .get(USERS_URL)
       .then((res) => {
@@ -42,19 +42,19 @@ function App() {
         }
       })
       .catch((error) => console.error(error));
-  };
+  },[setEstimation, setUserNameSubmitted]);
 
   useEffect(() => {
     const hash = window.location.hash.slice(1); // remove the "#" character
     if (hash) {
       setUserName(hash);
     }
-  }, []);
+  }, [setUserName]);
 
   // Fetch all users and their estimations from the server when the component mounts for the first time (i.e. when the page loads)
   useEffect(() => {
     updateUsers();
-  }, []);
+  }, [updateUsers]);
 
   useEffect(() => {
     const socket = io(SOCKETIO_SERVER_URL, {
@@ -73,7 +73,7 @@ function App() {
       setUserNameSubmitted(false);
     });
     return () => socket.disconnect();
-  }, []);
+  }, [setEstimation, setUserNameSubmitted, updateUsers]);
 
   const handleNameSubmit = (event) => {
     event.preventDefault();

--- a/src/App.js
+++ b/src/App.js
@@ -114,8 +114,8 @@ function App() {
       <main className="py-5">
         {userNameSubmitted ? (
           <div>
-            <div class="card mb-4">
-              <div class="card-body">
+            <div className="card mb-4">
+              <div className="card-body">
                 Good to see you {userName}, oh wise estimator. Now take your
                 guess:
                 <div className="estimation-buttons">

--- a/src/App.js
+++ b/src/App.js
@@ -48,7 +48,7 @@ function App() {
     sessionStorage.setItem("estimation", estimation);
     sessionStorage.setItem("userName", userName);
     sessionStorage.setItem("userNameSubmitted", userNameSubmitted);
-  });
+  }, [estimation, userName, userNameSubmitted]);
 
   useEffect(() => {
     const hash = window.location.hash.slice(1); // remove the "#" character

--- a/src/App.js
+++ b/src/App.js
@@ -11,21 +11,22 @@ import {
 } from "./constants";
 import "./estimationButtons.css";
 
+function useStateWithSessionStorage(key, initialValue) {
+  const [state, setState] = useState(
+    JSON.parse(sessionStorage.getItem(key)) || initialValue
+  );
+  useEffect(() => {
+    sessionStorage.setItem(key, JSON.stringify(state));
+  }, [key, state]);
+  return [state, setState];
+}
+
 function App() {
 
-  const [userName, setUserName] = useState(
-    sessionStorage.getItem("userName") || ""
-  );
-
   const [users, setUsers] = useState([]);
-
-  const [estimation, setEstimation] = useState(
-    sessionStorage.getItem("estimation") || null,
-  );
-
-  const [userNameSubmitted, setUserNameSubmitted] = useState(
-    sessionStorage.getItem("userNameSubmitted") || false,
-  );
+  const [userName, setUserName] = useStateWithSessionStorage("userName", "");
+  const [estimation, setEstimation] = useStateWithSessionStorage("estimation", null);
+  const [userNameSubmitted, setUserNameSubmitted] = useStateWithSessionStorage("userNameSubmitted", false);
 
   // create function to update users state by sending a GET request to the server
   const updateUsers = () => {
@@ -42,13 +43,6 @@ function App() {
       })
       .catch((error) => console.error(error));
   };
-
-  // Whenever state changes, write session data to sessionStorage
-  useEffect(() => {
-    sessionStorage.setItem("estimation", estimation);
-    sessionStorage.setItem("userName", userName);
-    sessionStorage.setItem("userNameSubmitted", userNameSubmitted);
-  }, [estimation, userName, userNameSubmitted]);
 
   useEffect(() => {
     const hash = window.location.hash.slice(1); // remove the "#" character

--- a/src/ResetArea.jsx
+++ b/src/ResetArea.jsx
@@ -1,6 +1,5 @@
 import React from "react";
 import axios from "axios";
-import PropTypes from "prop-types";
 import { ESTIMATIONS_URL, USERS_URL } from "./constants";
 
 function ResetArea() {
@@ -42,9 +41,5 @@ function ResetArea() {
 
   
 }
-
-ResetArea.propTypes = {
-  onClick: PropTypes.func.isRequired,
-};
 
 export default ResetArea;


### PR DESCRIPTION
@ingomohr this should fix #8.

I first "fixed" this problem by updating the condition for the `disabled` state as follows

```
disabled={estimation !== null && estimation !== "null"}
```

This was for analysis purposes only and not committed as it appeared to be a workaround.

Apparently, when a null value is stored in session storage, it is actually converted to the string "null", which is a non-null value.

My buddy ChatGPT fixed it by creating a new `useStateWithSessionStorage` hook which parses the session storage and defaults to the initial value if no value could be parsed.

Additionally, I fixed some ESLint warnings using suggested quick fixes.

I manually tested the app and couldn't find any other refreshing bugs.